### PR TITLE
build: gcc 10 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ jobs:
       fail-fast: false
       matrix:
         config:
+          - name: Linux GCC 10
+            os: ubuntu-22.04
+            compiler: g++-10
+
           - name: Linux GCC 14
             os: ubuntu-24.04
             compiler: g++-14

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,30 @@ else()
     target_compile_options(openae_project_options INTERFACE ${warnings})
 endif()
 
+# dependencies
+include(FetchContent)
+FetchContent_Declare(
+  fmt
+  GIT_REPOSITORY      https://github.com/fmtlib/fmt
+  GIT_TAG             11.1.4
+  EXCLUDE_FROM_ALL
+  SYSTEM
+  FIND_PACKAGE_ARGS   11.0.0...12.0.0
+)
+FetchContent_MakeAvailable(fmt)
+
+option(XXHASH_BUILD_XXHSUM "Build the xxhsum binary" OFF)
+FetchContent_Declare(
+    xxHash
+    GIT_REPOSITORY    https://github.com/Cyan4973/xxHash.git
+    GIT_TAG           v0.8.3
+    SOURCE_SUBDIR     cmake_unofficial
+    EXCLUDE_FROM_ALL
+    SYSTEM
+    FIND_PACKAGE_ARGS 0.8.3...0.9.0
+)
+FetchContent_MakeAvailable(xxHash)
+
 # library
 add_subdirectory(src)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,9 @@ FetchContent_Declare(
   FIND_PACKAGE_ARGS   11.0.0...12.0.0
 )
 FetchContent_MakeAvailable(fmt)
+if(TARGET fmt)
+    set_target_properties(fmt PROPERTIES CXX_CLANG_TIDY "")
+endif()
 
 option(XXHASH_BUILD_XXHSUM "Build the xxhsum binary" OFF)
 FetchContent_Declare(

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -7,7 +7,7 @@ FetchContent_Declare(
     GIT_TAG           v1.9.1
     EXCLUDE_FROM_ALL
     SYSTEM
-    FIND_PACKAGE_ARGS 1.9.1
+    FIND_PACKAGE_ARGS 1.9.0...2.0.0
 )
 FetchContent_MakeAvailable(benchmark)
 if(TARGET benchmark)

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -16,8 +16,9 @@ target_sources(
 target_link_libraries(
     openae_bindings_python
     PRIVATE
-        openae
         openae_project_options
+        openae
+        fmt::fmt
 )
 set_target_properties(
     openae_bindings_python

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -18,7 +18,7 @@ target_link_libraries(
     PRIVATE
         openae_project_options
         openae
-        fmt::fmt
+        fmt::fmt-header-only
 )
 set_target_properties(
     openae_bindings_python

--- a/bindings/python/src/openae.cpp
+++ b/bindings/python/src/openae.cpp
@@ -1,9 +1,9 @@
 #include <complex>
-#include <format>
 #include <memory_resource>
 #include <string>
 #include <utility>
 
+#include <fmt/format.h>
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
 #include <nanobind/stl/string.h>
@@ -22,7 +22,7 @@ struct PyInput {
     PySpectrum spectrum;
 
     std::string repr() const {
-        return std::format("Input(samplerate={}, timedata=..., spectrum=...)", samplerate);
+        return fmt::format("Input(samplerate={}, timedata=..., spectrum=...)", samplerate);
     }
 
     std::string str() const {
@@ -85,9 +85,7 @@ constexpr int py_log_level(openae::LogLevel level) noexcept {
     }
 }
 
-void py_log(
-    openae::LogLevel level, const char* msg, [[maybe_unused]] std::source_location location
-) {
+void py_log(openae::LogLevel level, const char* msg) {
     auto logger = nb::module_::import_("logging").attr("getLogger")("openae");
     // https://docs.python.org/3/library/logging.html#logrecord-objects
     nb::dict kwargs;  // NOLINT(*const-correctness), false positive

--- a/include/openae/common.hpp
+++ b/include/openae/common.hpp
@@ -4,7 +4,6 @@
 #include <functional>
 #include <memory>
 #include <memory_resource>
-#include <source_location>
 
 #include "openae/config.hpp"
 
@@ -19,8 +18,7 @@ enum class LogLevel : std::uint8_t {
     Fatal,
 };
 
-using Logger =
-    std::function<void(LogLevel level, const char* message, std::source_location location)>;
+using Logger = std::function<void(LogLevel level, const char* message)>;
 
 using MemoryResource = std::pmr::memory_resource;
 
@@ -34,11 +32,6 @@ struct Env {
     Cache* cache = nullptr;
 };
 
-OPENAE_EXPORT void log(
-    Env& env,
-    LogLevel level,
-    const char* msg,
-    std::source_location location = std::source_location::current()
-);
+OPENAE_EXPORT void log(Env& env, LogLevel level, const char* msg);
 
 }  // namespace openae

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,26 +1,3 @@
-include(FetchContent)
-FetchContent_Declare(
-  fmt
-  GIT_REPOSITORY      https://github.com/fmtlib/fmt
-  GIT_TAG             11.1.4
-  EXCLUDE_FROM_ALL
-  SYSTEM
-  FIND_PACKAGE_ARGS   11.0.0...12.0.0
-)
-FetchContent_MakeAvailable(fmt)
-
-option(XXHASH_BUILD_XXHSUM "Build the xxhsum binary" OFF)
-FetchContent_Declare(
-    xxHash
-    GIT_REPOSITORY    https://github.com/Cyan4973/xxHash.git
-    GIT_TAG           v0.8.3
-    SOURCE_SUBDIR     cmake_unofficial
-    EXCLUDE_FROM_ALL
-    SYSTEM
-    FIND_PACKAGE_ARGS 0.8.3...0.9.0
-)
-FetchContent_MakeAvailable(xxHash)
-
 configure_file(
     "${PROJECT_SOURCE_DIR}/include/openae/config.hpp.in"
     "${PROJECT_BINARY_DIR}/include/openae/config.hpp"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,14 @@
 include(FetchContent)
+FetchContent_Declare(
+  fmt
+  GIT_REPOSITORY      https://github.com/fmtlib/fmt
+  GIT_TAG             11.1.4
+  EXCLUDE_FROM_ALL
+  SYSTEM
+  FIND_PACKAGE_ARGS   11.0.0...12.0.0
+)
+FetchContent_MakeAvailable(fmt)
+
 option(XXHASH_BUILD_XXHSUM "Build the xxhsum binary" OFF)
 FetchContent_Declare(
     xxHash
@@ -7,7 +17,7 @@ FetchContent_Declare(
     SOURCE_SUBDIR     cmake_unofficial
     EXCLUDE_FROM_ALL
     SYSTEM
-    FIND_PACKAGE_ARGS 0.8.3
+    FIND_PACKAGE_ARGS 0.8.3...0.9.0
 )
 FetchContent_MakeAvailable(xxHash)
 
@@ -39,6 +49,7 @@ target_link_libraries(
     openae
     PRIVATE
         $<BUILD_INTERFACE:openae_project_options>
+        fmt::fmt
     PUBLIC
         # TODO: xxhash.h not found if PRIVATE
         $<BUILD_INTERFACE:xxHash::xxhash>  # effectively header-only with XXH_INLINE_ALL

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -1,8 +1,5 @@
 #include "openae/common.hpp"
 
-#include <memory>
-#include <source_location>
-
 #include "cache.hpp"
 
 namespace openae {

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -16,9 +16,9 @@ std::unique_ptr<Cache, void (*)(Cache*)> make_cache() {
     return {new Cache, &delete_func<Cache>};
 }
 
-void log(Env& env, LogLevel level, const char* msg, std::source_location location) {
+void log(Env& env, LogLevel level, const char* msg) {
     if (env.logger != nullptr) {
-        env.logger(level, msg, location);
+        env.logger(level, msg);
     }
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ FetchContent_Declare(
     GIT_TAG           v3.8.0
     EXCLUDE_FROM_ALL
     SYSTEM
-    FIND_PACKAGE_ARGS 3.8.0
+    FIND_PACKAGE_ARGS 3.8.0...4.0.0
 )
 FetchContent_MakeAvailable(Catch2)
 if(TARGET Catch2)
@@ -20,7 +20,7 @@ FetchContent_Declare(
     GIT_TAG           v3.4.0
     EXCLUDE_FROM_ALL
     SYSTEM
-    FIND_PACKAGE_ARGS 3.4.0
+    FIND_PACKAGE_ARGS 3.4.0...4.0.0
 )
 FetchContent_MakeAvailable(tomlplusplus)
 

--- a/tests/test_features.cpp
+++ b/tests/test_features.cpp
@@ -1,7 +1,6 @@
 #include <algorithm>
 #include <array>
 #include <filesystem>
-#include <format>
 #include <map>
 #include <stdexcept>
 #include <string>
@@ -146,7 +145,7 @@ R compute_feature(
     for_each(args, [&, index = size_t{0}]<typename Arg>(Arg& arg) mutable {
         const auto& param_name = param_names.at(index++);
         if (not param_values.contains(param_name)) {
-            throw std::runtime_error(std::format("Parameter not found: {}", param_name));
+            throw std::runtime_error(std::string{"Parameter not found: "}.append(param_name));
         }
         arg = static_cast<Arg>(param_values.at(param_name));
     });

--- a/tests/tostring.hpp
+++ b/tests/tostring.hpp
@@ -1,4 +1,4 @@
-#include <format>
+#include <sstream>
 #include <string>
 #include <utility>
 
@@ -9,7 +9,9 @@ namespace Catch {
 template <typename T1, typename T2>
 struct StringMaker<std::pair<T1, T2>> {
     static std::string convert(const std::pair<T1, T2>& pair) {
-        return std::format("({},{})", pair.first, pair.second);
+        std::ostringstream oss;
+        oss << "(" << pair.first << "," << pair.second << ")";
+        return oss.str();
     }
 };
 


### PR DESCRIPTION
GCC 10 doesn't have full C++20 support:
- Use `fmt` library instead of `<format>` header
- Don't use `<source_location>` header