### PR TITLE
fix(partial-power): rounding function

### DIFF
--- a/tests/test_features_partial-power.toml
+++ b/tests/test_features_partial-power.toml
@@ -62,6 +62,6 @@ input.samplerate = 10
 input.spectrum = [0, 1, 2, 3, 4, 0] # sum squares: 30
 # frequencies:    0, 1, 2, 3, 4, 5 Hz
 #                          ^
-params.fmin = 3.4 # round down to bin 3
-params.fmax = 3.6 # round up to bin 4
+params.fmin = 3.4 # floor to bin 3
+params.fmax = 4.6 # floor to bin 4
 result = 0.3 # 9/30


### PR DESCRIPTION
Use flooring instead of rounding to transform frequencies to bins.