### PR TITLE
ci: update GitHub Actions and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      github-actions:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
 
     runs-on: ${{ matrix.config.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Configure CMake
         run: >
           cmake -S . -B build

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -15,8 +15,8 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
       - name: Build and install
@@ -42,7 +42,7 @@ jobs:
           - os: macos-15
             platform: macos
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Build wheels
         env:
           # <memory_resource> requires 14.0: https://developer.apple.com/xcode/cpp/
@@ -51,7 +51,7 @@ jobs:
           CIBW_ARCHS_MACOS: "x86_64 arm64" # https://cibuildwheel.pypa.io/en/stable/faq/#cross-compiling
           CIBW_PLATFORM: ${{ matrix.config.platform }}
         uses: pypa/cibuildwheel@v4.1.0
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: cibw-wheels-${{ matrix.config.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
@@ -60,10 +60,10 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Build sdist
         run: pipx run build --sdist
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: cibw-sdist
           path: ./dist/*.tar.gz
@@ -81,7 +81,7 @@ jobs:
       id-token: write
     steps:
     - name: Download all artifacts
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v8
       with:
         path: dist/
         pattern: cibw-*

--- a/.github/workflows/vamp.yml
+++ b/.github/workflows/vamp.yml
@@ -30,7 +30,7 @@ jobs:
             os: windows-2022
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # tags + history for git describe
 
@@ -75,7 +75,7 @@ jobs:
           version="${version#v}"
           cmake -E tar cf "../openae-vamp-${version}-${{ matrix.config.name }}.zip" --format=zip -- .
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: vamp-${{ matrix.config.name }}
           path: openae-vamp-*.zip
@@ -86,7 +86,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@v8
         with:
           pattern: vamp-*
           path: artifacts/
@@ -113,7 +113,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@v8
         with:
           pattern: vamp-*
           path: artifacts/


### PR DESCRIPTION
## Summary

- Update all `actions/*` to their latest major versions: checkout v6 → v7, setup-python v6 → v7, upload-artifact v6 → v7, download-artifact v6 → v8
- Add `.github/dependabot.yml` (github-actions ecosystem, monthly, grouped into a single PR) so future action updates arrive automatically

`pypa/cibuildwheel` is intentionally left at v4.1.0 (bumped in dedicated commits) and `pypa/gh-action-pypi-publish` already floats on `release/v1`; Dependabot will cover both going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)