### PR TITLE
build(python): migrate to PEP 735 dependency groups

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -19,8 +19,10 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip # dependency groups require pip >= 25.1
       - name: Build and install
-        run: pip install --verbose .[tests]
+        run: pip install --verbose . --group tests
       - name: Run tests with pytest
         run: pytest
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,13 +8,11 @@ build:
     - build-essential
     - cmake
     - doxygen
-
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
+  jobs:
+    # RTD seeds an old pip into the venv; --group needs pip >= 25.1
+    install:
+      - python -m pip install --upgrade pip
+      - python -m pip install . --group docs
 
 sphinx:
   configuration: docs/conf.py

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -16,7 +16,7 @@ target_sources(
 target_link_libraries(
     openae_bindings_python_features
     PRIVATE
-        openae
+        openae::openae
         openae_project_options
 )
 set_target_properties(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,13 @@ keywords = [
 ]
 dependencies = ["numpy>=1.20"]
 
-[project.optional-dependencies]
+[project.urls]
+Homepage = "https://openae.io"
+Source = "https://github.com/openae-io/openae-lib"
+Issues = "https://github.com/openae-io/openae-lib/issues"
+Changelog = "https://github.com/openae-io/openae-lib/blob/main/CHANGELOG.md"
+
+[dependency-groups] # PEP 735, requires pip >= 25.1 or uv
 docs = [
     "sphinx>=8",
     "sphinx-autodoc-typehints",
@@ -61,14 +67,10 @@ tools = [
     "ruff>=0.9",
 ]
 dev = [
-    "openae[docs,tests,tools]", # recursive dependency since pip 21.2
+    { include-group = "docs" },
+    { include-group = "tests" },
+    { include-group = "tools" },
 ]
-
-[project.urls]
-Homepage = "https://openae.io"
-Source = "https://github.com/openae-io/openae-lib"
-Issues = "https://github.com/openae-io/openae-lib/issues"
-Changelog = "https://github.com/openae-io/openae-lib/blob/main/CHANGELOG.md"
 
 [tool.coverage.run]
 branch = true
@@ -141,7 +143,7 @@ skip = [
 ]
 build-verbosity = 1
 test-command = "pytest {project}/bindings/python/tests"
-test-requires = ["pytest", "pytest-benchmark"]
+test-groups = ["tests"]
 # select images with C++ 20 support: https://github.com/pypa/manylinux
 # manylinux_2_28 with GCC 14
 manylinux-x86_64-image = "manylinux_2_28"


### PR DESCRIPTION
Move docs/tests/tools/dev from [project.optional-dependencies] to [dependency-groups]. These are development dependencies and don't belong in the published package metadata. The dev group now uses include-group instead of the self-referencing openae[docs,tests,tools] extra.

Update the consumers accordingly:
- CI installs with `pip install . --group tests`
- cibuildwheel uses test-groups instead of a duplicated test-requires
- Read the Docs installs via build.jobs.install, since the python.install key has no dependency group support

Requires pip >= 25.1, hence the pip upgrade steps. Note that dependency groups are not part of the wheel/sdist metadata, so `pip install openae[tests]` no longer works.